### PR TITLE
Change "instable" to "unstable"

### DIFF
--- a/src/Commands/MiscCommands.cs
+++ b/src/Commands/MiscCommands.cs
@@ -156,7 +156,7 @@ namespace Essentials.Commands {
                         return CommandResult.Lang("COMMAND_NO_PERMISSION");
                     }
 
-                    src.SendMessage("This command is instable and can cause bugs.", Color.red);
+                    src.SendMessage("This command is unstable and can cause bugs.", Color.red);
 
                     var toRemove = new List<uint>();
                     UWorld.Vehicles


### PR DESCRIPTION
I have a script that automatically does /clear ev. So I saw this and was bothered by it.