### PR TITLE
Fix kit cooldown loading

### DIFF
--- a/src/NativeModules/Kit/Data/CooldownData.cs
+++ b/src/NativeModules/Kit/Data/CooldownData.cs
@@ -41,9 +41,11 @@ namespace Essentials.NativeModules.Kit.Data {
             }
 
             var saved = JsonUtil.DeserializeFile<Dictionary<ulong, PlayerCooldown>>(FilePath);
+            
+            CommandKit.Cooldowns.Clear();
+            CommandKit.GlobalCooldown.Clear();
+            
             saved.ForEach(kv => {
-                CommandKit.Cooldowns.Clear();
-                CommandKit.GlobalCooldown.Clear();
                 if (kv.Value.Kits != null) {
                     CommandKit.Cooldowns.Add(kv.Key, kv.Value.Kits);
                 }


### PR DESCRIPTION
Fixed the fact that only the last saved cooldown was kept in memory when loading, causing the beautiful issues of https://github.com/uEssentials/uEssentials/issues/615.